### PR TITLE
Slack uses `trigger_word` instead of `command` in request body

### DIFF
--- a/routes/list.js
+++ b/routes/list.js
@@ -22,7 +22,7 @@ var listExists = false;
 router.post('/', function(req, res) {
 
   var rbody = req.body,
-    trigger = rbody.command,
+    trigger = rbody.trigger_word,
     item = rbody.text.replace(new RegExp(trigger, 'gi'), '').trim(),
     channelId = rbody.channel_id,
     userId = rbody.user_id,


### PR DESCRIPTION
¯_(ツ)_/¯ 
